### PR TITLE
[#17] Handling of unknown or missing transformation IDs

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -22,7 +22,7 @@ if(!in_array($service, $services)){
 if($service == "transformations"){
 	$transformation = get_url_parameter('transformation');
 	$version = get_url_parameter('version');
-	if($transformation != ""){
+	if($transformation != "" && file_exists("transformations/".str_pad($transformation, $padding_width, '0', STR_PAD_LEFT))){
 		$filename = get_url_parameter('filename');
 		$transformation_id_padded = str_pad($transformation, $padding_width, '0', STR_PAD_LEFT);
 		

--- a/api/index.php
+++ b/api/index.php
@@ -25,7 +25,7 @@ if($service == "transformations"){
 	if($transformation != "" && file_exists("transformations/".str_pad($transformation, $padding_width, '0', STR_PAD_LEFT))){
 		$filename = get_url_parameter('filename');
 		$transformation_id_padded = str_pad($transformation, $padding_width, '0', STR_PAD_LEFT);
-		
+
 		if($version != ""){
 			$version_padded = str_pad($version, $padding_width, '0', STR_PAD_LEFT);
 			$file = "transformations/".$transformation_id_padded."/".$version_padded."/index.json";
@@ -171,25 +171,29 @@ if($service == "transformations"){
 			$output["transformations"][] = $latest_version_content["version"];
 		}
 		
-		
 		header('Content-Type: application/json; charset=utf-8');
-		
 
 		echo json_encode($output);
-		//
 	}
 }else if($service == "transform"){
-	//get GET parameters
 	$transformation = get_url_parameter('transformation');
 	$version = get_url_parameter('version');
 	$input_file_url = get_url_parameter('input_file_url');
 	$input_file_zipped = get_url_parameter('input_file_zipped',"false");
 	//ToDo load additional custom parameters
 	//print_r($_GET);
-	//load transformation
 	
 	if($transformation != ""){
 		$transformation_id_padded = str_pad($transformation, $padding_width, '0', STR_PAD_LEFT);
+		if(!file_exists("transformations/".$transformation_id_padded)){
+			header('Content-Type: application/json; charset=utf-8');
+			http_response_code (404);
+			$output = array();
+			$output["error_code"] = 404;
+			$output["error_message"] = "Transformation ID not found";
+			echo json_encode($output);
+			return;
+		}
 		
 		if($version != ""){
 			$version_padded = str_pad($version, $padding_width, '0', STR_PAD_LEFT);
@@ -229,8 +233,12 @@ if($service == "transformations"){
 			
 		}
 	}else{
-		//to transformation specified
-		//ToDo warning
+		header('Content-Type: application/json; charset=utf-8');
+		http_response_code (404);
+		$output = array();
+		$output["error_code"] = 404;
+		$output["error_message"] = "No transformation ID specified";
+		echo json_encode($output);
 		return;
 	}
 	

--- a/config.php
+++ b/config.php
@@ -1,6 +1,6 @@
 <?php
 
 # Available services
-$services = array('transformations', 'transform');
+$services = array('transformations', 'transform', 'results');
 
 ?>  


### PR DESCRIPTION
#### Tickets
[#17]

#### Justification
It might happen for a DTS request to be sent without a transformation ID or with one that does not exist in the web service. For this reason, it is important to identify such requests and to inform the client about the error.

#### Code changes
index.php
- transformation: check for a given ID if _index.json_ exists for this path. If not, return a list of available transformations (already implemented)
- transform: check for a given ID if _index.json_ exists for this path. If not, return a JSON including error code and message. The same kind of response is returned if the no ID has been specified (in `else`)

config.php
- added results to the available services
