### PR TITLE
[#26] Deletion of results with a given ID

### DIFF
--- a/api/.htaccess
+++ b/api/.htaccess
@@ -9,5 +9,5 @@ RewriteRule ^transformations/(\d+)/(\d+)/?$ index.php?service=transformations&tr
 RewriteRule ^transformations/(\d+)/(\d+)/([^/]*)$ index.php?service=transformations&transformation=$1&version=$2&filename=$3 [L]
 RewriteRule ^transformations/(\d+)/([^/]*)$ index.php?service=transformations&transformation=$1&filename=$2 [L]
 RewriteRule ^results/(\d+)/?$ index.php?service=results&job=$1 [L]
-RewriteRule ^results/(\d+)/delete/?$ index.php?service=results&job=$1&task=delete [L]
+# RewriteRule ^results/(\d+)/delete/?$ index.php?service=results&job=$1&task=delete [L]
 </IfModule>

--- a/api/index.php
+++ b/api/index.php
@@ -5,8 +5,9 @@ include("utils.php");
 include("pdi.php");
 include("../config.php");
 
-$padding_width = 4;
+$method = $_SERVER['REQUEST_METHOD'];
 $service = get_url_parameter('service');
+$padding_width = 4;
 
 if(!in_array($service, $services)){
 	header('Content-Type: application/json; charset=utf-8');
@@ -19,369 +20,378 @@ if(!in_array($service, $services)){
 	return;
 }
 
-if($service == "transformations"){
-	$transformation = get_url_parameter('transformation');
-	$version = get_url_parameter('version');
-	if($transformation != "" && file_exists("transformations/".str_pad($transformation, $padding_width, '0', STR_PAD_LEFT))){
-		$filename = get_url_parameter('filename');
-		$transformation_id_padded = str_pad($transformation, $padding_width, '0', STR_PAD_LEFT);
+if ($method == 'GET') {
+	if($service == "transformations"){
+		$transformation = get_url_parameter('transformation');
+		$version = get_url_parameter('version');
+		if($transformation != "" && file_exists("transformations/".str_pad($transformation, $padding_width, '0', STR_PAD_LEFT))){
+			$filename = get_url_parameter('filename');
+			$transformation_id_padded = str_pad($transformation, $padding_width, '0', STR_PAD_LEFT);
 
-		if($version != ""){
-			$version_padded = str_pad($version, $padding_width, '0', STR_PAD_LEFT);
-			$file = "transformations/".$transformation_id_padded."/".$version_padded."/index.json";
+			if($version != ""){
+				$version_padded = str_pad($version, $padding_width, '0', STR_PAD_LEFT);
+				$file = "transformations/".$transformation_id_padded."/".$version_padded."/index.json";
 
-			if (file_exists($file)) {					
-				$string = file_get_contents($file);
-				$json = json_decode($string, true);
-				$json["version"] = array_merge(array("transformation_id"=>ltrim($transformation, '0'),"version_id"=>ltrim($version, '0')),$json["version"]);
+				if (file_exists($file)) {					
+					$string = file_get_contents($file);
+					$json = json_decode($string, true);
+					$json["version"] = array_merge(array("transformation_id"=>ltrim($transformation, '0'),"version_id"=>ltrim($version, '0')),$json["version"]);
+					
+					header('Content-Type: application/json; charset=utf-8');
+					echo json_encode($json);
+				}else{
+					$latest_version_id_padded = get_latest_version($transformation_id_padded);
+					header('Content-Type: application/json; charset=utf-8');
+					http_response_code (404);
+					$output = array();
+					$output["error_code"] = 404;
+					$output["error_message"] = "Version not found";
+					$output["transformation"]["latest_version"] = array("transformation_id"=>ltrim($transformation, '0'),"version_id"=>ltrim($latest_version_id_padded, '0'));
+
+					echo json_encode($output);
+					return;
+				}
+						
+			}else if($filename != ""){
+				$filename = str_replace("\"","",$filename);
+				$version_id_padded = get_latest_version($transformation_id_padded);
+				$file = "transformations/".$transformation_id_padded."/".$version_id_padded."/".$filename;
+				if (file_exists($file)) {
+					$json = file_get_contents($file);
+					header('Content-Type: application/json; charset=utf-8');
+					echo $json;
+					return;
+				}else{
+					header('Content-Type: application/json; charset=utf-8');
+					http_response_code (404);
+					$output = array();
+					$output["error_code"] = 404;
+					$output["error_message"] = "File not found";
+					echo json_encode($output);
+					return;
+				}
+			}else{
+				$listing = array();
+				foreach (new DirectoryIterator($service."/".$transformation_id_padded) as $fileInfo) {
+					if($fileInfo->isDir() && !$fileInfo->isDot() && $fileInfo->getFilename() != "." && $fileInfo->getFilename() != ".." ) {
+						$file = $service."/".$transformation_id_padded."/".$fileInfo->getFilename()."/index.json";
+
+						if (file_exists($file)) {
+							
+							$string = file_get_contents($file);
+							$json = json_decode($string, true);
+							//ToDo deprecated tracking
+							if(array_key_exists('published', $json['version']) && ($json['version']['published'] == "false" || $json['version']['published'] == "hidden" )){
+								continue;
+							}
+							
+							$listing[] = $fileInfo->getFilename();
+						}
+					}
+				}
+				if (sizeof($listing) == 0) {
+					header('Content-Type: application/json; charset=utf-8');
+					http_response_code (404);
+					$output = array();
+					$output["error_code"] = 404;
+					$output["error_message"] = "Transformation not found";
+					echo json_encode($output);
+					return;
+				}
+				
+				sort($listing);
+				$latest_version_id_padded = $listing[sizeof($listing)-1];
 				
 				header('Content-Type: application/json; charset=utf-8');
-				echo json_encode($json);
-			}else{
-				$latest_version_id_padded = get_latest_version($transformation_id_padded);
-				header('Content-Type: application/json; charset=utf-8');
-				http_response_code (404);
 				$output = array();
-				$output["error_code"] = 404;
-				$output["error_message"] = "Version not found";
-				$output["transformation"]["latest_version"] = array("transformation_id"=>ltrim($transformation, '0'),"version_id"=>ltrim($latest_version_id_padded, '0'));
-
-				echo json_encode($output);
-				return;
-			}
+				
+				$file = "transformations/".$transformation_id_padded."/".$latest_version_id_padded."/index.json";
 					
-		}else if($filename != ""){
-			$filename = str_replace("\"","",$filename);
-			$version_id_padded = get_latest_version($transformation_id_padded);
-			$file = "transformations/".$transformation_id_padded."/".$version_id_padded."/".$filename;
-			if (file_exists($file)) {
-				$json = file_get_contents($file);
+				$string = file_get_contents($file);
+				$latest_version_content = json_decode($string, true);
+				$output["transformation"] = $latest_version_content["version"];	
+				$output["transformation"] = array_merge(array("transformation_id"=>ltrim($transformation, '0')),$output["transformation"]);
 				header('Content-Type: application/json; charset=utf-8');
-				echo $json;
-				return;
-			}else{
-				header('Content-Type: application/json; charset=utf-8');
-				http_response_code (404);
-				$output = array();
-				$output["error_code"] = 404;
-				$output["error_message"] = "File not found";
+				foreach ($listing as $version_id_padded) {
+					$file = "transformations/".$transformation_id_padded."/".$version_id_padded."/index.json";
+					$string = file_get_contents($file);
+					$version_content = json_decode($string, true);
+					$version_content["version"] = array_merge(array("transformation_id"=>ltrim($transformation, '0'),"version_id"=>ltrim($version_id_padded, '0')),$version_content["version"]);
+					$output["transformation"]["versions"][] = $version_content["version"];
+				}
 				echo json_encode($output);
-				return;
 			}
 		}else{
-			$listing = array();
-			foreach (new DirectoryIterator($service."/".$transformation_id_padded) as $fileInfo) {
+			//ToDo: list all available transformations
+			//header('Content-Type: application/json; charset=utf-8');
+			//echo "{\"transformations\": []}";
+			
+			//ToDo combine versions
+				//filter for unpublished flag
+				
+			$output = array();
+			$transformation_listing = array();
+			foreach (new DirectoryIterator($service) as $fileInfo) {
 				if($fileInfo->isDir() && !$fileInfo->isDot() && $fileInfo->getFilename() != "." && $fileInfo->getFilename() != ".." ) {
-					$file = $service."/".$transformation_id_padded."/".$fileInfo->getFilename()."/index.json";
-
-					if (file_exists($file)) {
-						
-						$string = file_get_contents($file);
-						$json = json_decode($string, true);
-						//ToDo deprecated tracking
-						if(array_key_exists('published', $json['version']) && ($json['version']['published'] == "false" || $json['version']['published'] == "hidden" )){
-							continue;
-						}
-						
-						$listing[] = $fileInfo->getFilename();
-					}
+					$transformation_listing[] = $fileInfo->getFilename();
 				}
 			}
-			if (sizeof($listing) == 0) {
+			sort($transformation_listing);
+			
+			foreach ($transformation_listing as $transformation_id_padded) {
+				$file = $service."/".$fileInfo->getFilename();
+					
+				$version_listing = array();
+				foreach (new DirectoryIterator($service."/".$transformation_id_padded) as $fileInfo) {
+					if($fileInfo->isDir() && !$fileInfo->isDot() && $fileInfo->getFilename() != "." && $fileInfo->getFilename() != ".." ) {
+						$file = $service."/".$transformation_id_padded."/".$fileInfo->getFilename()."/index.json";
+
+						if (file_exists($file)) {
+							
+							$string = file_get_contents($file);
+							$json = json_decode($string, true);
+							//ToDo deprecated tracking
+							if(array_key_exists('published', $json['version']) && ($json['version']['published'] == "false" || $json['version']['published'] == "hidden" )){
+								continue;
+							}
+							
+							$version_listing[] = $fileInfo->getFilename();
+						}
+					}
+				}
+				if (sizeof($version_listing) == 0) {
+					continue;
+				}
+				sort($version_listing);
+				$latest_version_id_padded = $version_listing[sizeof($version_listing)-1];
+
+				$file = "transformations/".$transformation_id_padded."/".$latest_version_id_padded."/index.json";
+			
+				$string = file_get_contents($file);
+				$latest_version_content = json_decode($string, true);
+				$latest_version_content["version"] = array_merge(array("transformation_id"=>ltrim($transformation_id_padded, '0'),"version_id"=>ltrim($latest_version_id_padded, '0')),$latest_version_content["version"]);
+				$output["transformations"][] = $latest_version_content["version"];
+			}
+			
+			header('Content-Type: application/json; charset=utf-8');
+
+			echo json_encode($output);
+		}
+	}else if($service == "transform"){
+		$transformation = get_url_parameter('transformation');
+		$version = get_url_parameter('version');
+		$input_file_url = get_url_parameter('input_file_url');
+		$input_file_zipped = get_url_parameter('input_file_zipped',"false");
+		//ToDo load additional custom parameters
+		//print_r($_GET);
+		
+		if($transformation != ""){
+			$transformation_id_padded = str_pad($transformation, $padding_width, '0', STR_PAD_LEFT);
+			if(!file_exists("transformations/".$transformation_id_padded)){
 				header('Content-Type: application/json; charset=utf-8');
 				http_response_code (404);
 				$output = array();
 				$output["error_code"] = 404;
-				$output["error_message"] = "Transformation not found";
+				$output["error_message"] = "Transformation ID not found";
 				echo json_encode($output);
 				return;
 			}
 			
-			sort($listing);
-			$latest_version_id_padded = $listing[sizeof($listing)-1];
-			
-			header('Content-Type: application/json; charset=utf-8');
-			$output = array();
-			
-			$file = "transformations/".$transformation_id_padded."/".$latest_version_id_padded."/index.json";
-				
-			$string = file_get_contents($file);
-			$latest_version_content = json_decode($string, true);
-			$output["transformation"] = $latest_version_content["version"];	
-			$output["transformation"] = array_merge(array("transformation_id"=>ltrim($transformation, '0')),$output["transformation"]);
-			header('Content-Type: application/json; charset=utf-8');
-			foreach ($listing as $version_id_padded) {
-				$file = "transformations/".$transformation_id_padded."/".$version_id_padded."/index.json";
-				$string = file_get_contents($file);
-				$version_content = json_decode($string, true);
-				$version_content["version"] = array_merge(array("transformation_id"=>ltrim($transformation, '0'),"version_id"=>ltrim($version_id_padded, '0')),$version_content["version"]);
-				$output["transformation"]["versions"][] = $version_content["version"];
-			}
-			echo json_encode($output);
-		}
-	}else{
-		//ToDo: list all available transformations
-		//header('Content-Type: application/json; charset=utf-8');
-		//echo "{\"transformations\": []}";
-		
-		//ToDo combine versions
-			//filter for unpublished flag
-			
-		$output = array();
-		$transformation_listing = array();
-		foreach (new DirectoryIterator($service) as $fileInfo) {
-			if($fileInfo->isDir() && !$fileInfo->isDot() && $fileInfo->getFilename() != "." && $fileInfo->getFilename() != ".." ) {
-				$transformation_listing[] = $fileInfo->getFilename();
-			}
-		}
-		sort($transformation_listing);
-		
-		foreach ($transformation_listing as $transformation_id_padded) {
-			$file = $service."/".$fileInfo->getFilename();
-				
-			$version_listing = array();
-			foreach (new DirectoryIterator($service."/".$transformation_id_padded) as $fileInfo) {
-				if($fileInfo->isDir() && !$fileInfo->isDot() && $fileInfo->getFilename() != "." && $fileInfo->getFilename() != ".." ) {
-					$file = $service."/".$transformation_id_padded."/".$fileInfo->getFilename()."/index.json";
+			if($version != ""){
+				$version_padded = str_pad($version, $padding_width, '0', STR_PAD_LEFT);
+				$file = "transformations/".$transformation_id_padded."/".$version_padded."/index.json";
 
-					if (file_exists($file)) {
+				if (file_exists($file)) {					
+					$transformation_file = $file;
+				}else{
+					$latest_version_id_padded = get_latest_version($transformation_id_padded);
+					header('Content-Type: application/json; charset=utf-8');
+					http_response_code (404);
+					$output = array();
+					$output["error_code"] = 404;
+					$output["error_message"] = "Version not found";
+					$output["transformation"]["latest_version"] = array("transformation_id"=>ltrim($transformation, '0'),"version_id"=>ltrim($latest_version_id_padded, '0'));
+
+					echo json_encode($output);
+					return;
+				}
 						
-						$string = file_get_contents($file);
-						$json = json_decode($string, true);
-						//ToDo deprecated tracking
-						if(array_key_exists('published', $json['version']) && ($json['version']['published'] == "false" || $json['version']['published'] == "hidden" )){
-							continue;
+			}else{
+				$listing = array();
+				foreach (new DirectoryIterator("transformations/".$transformation_id_padded) as $fileInfo) {
+					if($fileInfo->isDir() && !$fileInfo->isDot() && $fileInfo->getFilename() != "." && $fileInfo->getFilename() != ".." ) {
+						$file = "transformations/".$transformation_id_padded."/".$fileInfo->getFilename()."/index.json";
+
+						if (file_exists($file)) {
+							$listing[] = $fileInfo->getFilename();
 						}
-						
-						$version_listing[] = $fileInfo->getFilename();
 					}
 				}
+				sort($listing);
+				$latest_version_id_padded = $listing[sizeof($listing)-1];
+				$version = $latest_version_id_padded;
+				
+				$transformation_file = "transformations/".$transformation_id_padded."/".$latest_version_id_padded."/index.json";
+				
 			}
-			if (sizeof($version_listing) == 0) {
-				continue;
-			}
-			sort($version_listing);
-			$latest_version_id_padded = $version_listing[sizeof($version_listing)-1];
-
-			$file = "transformations/".$transformation_id_padded."/".$latest_version_id_padded."/index.json";
-		
-			$string = file_get_contents($file);
-			$latest_version_content = json_decode($string, true);
-			$latest_version_content["version"] = array_merge(array("transformation_id"=>ltrim($transformation_id_padded, '0'),"version_id"=>ltrim($latest_version_id_padded, '0')),$latest_version_content["version"]);
-			$output["transformations"][] = $latest_version_content["version"];
-		}
-		
-		header('Content-Type: application/json; charset=utf-8');
-
-		echo json_encode($output);
-	}
-}else if($service == "transform"){
-	$transformation = get_url_parameter('transformation');
-	$version = get_url_parameter('version');
-	$input_file_url = get_url_parameter('input_file_url');
-	$input_file_zipped = get_url_parameter('input_file_zipped',"false");
-	//ToDo load additional custom parameters
-	//print_r($_GET);
-	
-	if($transformation != ""){
-		$transformation_id_padded = str_pad($transformation, $padding_width, '0', STR_PAD_LEFT);
-		if(!file_exists("transformations/".$transformation_id_padded)){
+		}else{
 			header('Content-Type: application/json; charset=utf-8');
 			http_response_code (404);
 			$output = array();
 			$output["error_code"] = 404;
-			$output["error_message"] = "Transformation ID not found";
+			$output["error_message"] = "No transformation ID specified";
 			echo json_encode($output);
 			return;
 		}
 		
-		if($version != ""){
-			$version_padded = str_pad($version, $padding_width, '0', STR_PAD_LEFT);
-			$file = "transformations/".$transformation_id_padded."/".$version_padded."/index.json";
-
-			if (file_exists($file)) {					
-				$transformation_file = $file;
-			}else{
-				$latest_version_id_padded = get_latest_version($transformation_id_padded);
-				header('Content-Type: application/json; charset=utf-8');
-				http_response_code (404);
-				$output = array();
-				$output["error_code"] = 404;
-				$output["error_message"] = "Version not found";
-				$output["transformation"]["latest_version"] = array("transformation_id"=>ltrim($transformation, '0'),"version_id"=>ltrim($latest_version_id_padded, '0'));
-
-				echo json_encode($output);
+		if($transformation_file != ""){
+			$string = file_get_contents($file);
+			$transformation_json = json_decode($string, true);
+			$transformation_json["version"] = array_merge(array("transformation_id"=>ltrim($transformation, '0'),"version_id"=>ltrim($version, '0')),$transformation_json["version"]);
+			
+			do{
+			$job_json = array();
+			//
+			$job_id = rand(0,9999999999);
+			$job_id_token_width = 10;
+			$job_id = str_pad($job_id, $job_id_token_width, '0', STR_PAD_LEFT);
+				
+			}while(file_exists("results/".$job_id));
+				
+			mkdir("results/".$job_id);
+			mkdir("results/".$job_id."/input");
+			mkdir("results/".$job_id."/output");
+			mkdir("results/".$job_id."/tmp");
+			
+			$job_json["job"]["job_id"] = $job_id;
+			$job_json["job"]["transformation_id"] = ltrim($transformation, '0');
+			$job_json["job"]["version_id"] = ltrim($version, '0');
+			$job_json["job"]["input_file_url"] = $input_file_url;
+			$job_json["job"]["input_file_zipped"] = $input_file_zipped;
+			$job_json["job"]["query"] = (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) ? 'https' : 'http')."://".$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
+			//ToDo error handling urls with parameters or slash at the end
+			$input_file_name = substr($input_file_url, strrpos($input_file_url,"/")+1);
+			$url = substr($input_file_url, 0, strrpos($input_file_url,"/")+1);
+			$job_json["job"]["input_file"] = "input/".$input_file_name;
+			//error_log($url);
+			//error_log($input_file_name, 0);
+			//error_log($input_file_url, 0);
+			error_log($url . rawurlencode($input_file_name));
+			//error_log(rawurlencode($input_file_url));
+			
+			$input_file_url = $url . rawurlencode($input_file_name);
+			$input_file_url = str_replace("%3F", "?", $input_file_url);
+			$input_file_url = str_replace("%26", "&", $input_file_url);
+			if (!filter_var($input_file_url, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE) && !filter_var($url, FILTER_VALIDATE_URL)) {
+				echo "Invalid URL";
 				return;
 			}
-					
-		}else{
-			$listing = array();
-			foreach (new DirectoryIterator("transformations/".$transformation_id_padded) as $fileInfo) {
-				if($fileInfo->isDir() && !$fileInfo->isDot() && $fileInfo->getFilename() != "." && $fileInfo->getFilename() != ".." ) {
-					$file = "transformations/".$transformation_id_padded."/".$fileInfo->getFilename()."/index.json";
-
-					if (file_exists($file)) {
-						$listing[] = $fileInfo->getFilename();
-					}
+			$input_file_content = @file_get_contents($input_file_url);
+			$length = strlen($input_file_content);
+			if ($length == 0) {
+				//ToDo error handling
+				echo "Error: File not found";
+				return;
+			}
+			elseif ($length > 100000000) {
+				// ToDo error handling
+				echo "Error: File larger than 100MB";
+				return;
+			}
+			elseif ($job_json["job"]["transformation_id"] == "5" && substr($input_file_content, 0, 5) != "<?xml") {
+				//ToDo error handling
+				echo "Error: File is not XML";
+				return;
+			}
+			if ($input_file_content)
+				file_put_contents("results/".$job_id."/".$job_json["job"]["input_file"],$input_file_content);
+			
+			foreach ($_GET as $parameter => $value) {
+				if(substr($parameter,0,1)=="_"){
+					$job_json["job"]["parameters"][substr($parameter,1)] = $value;
 				}
 			}
-			sort($listing);
-			$latest_version_id_padded = $listing[sizeof($listing)-1];
-			$version = $latest_version_id_padded;
+			$job_json["job"]["status"] = "processing";
+			$job_json["job"]["start_time"] = date("c");
 			
-			$transformation_file = "transformations/".$transformation_id_padded."/".$latest_version_id_padded."/index.json";
 			
-		}
-	}else{
-		header('Content-Type: application/json; charset=utf-8');
-		http_response_code (404);
-		$output = array();
-		$output["error_code"] = 404;
-		$output["error_message"] = "No transformation ID specified";
-		echo json_encode($output);
-		return;
-	}
-	
-	if($transformation_file != ""){
-		$string = file_get_contents($file);
-		$transformation_json = json_decode($string, true);
-		$transformation_json["version"] = array_merge(array("transformation_id"=>ltrim($transformation, '0'),"version_id"=>ltrim($version, '0')),$transformation_json["version"]);
-		
-		do{
-		$job_json = array();
-		//
-		$job_id = rand(0,9999999999);
-		$job_id_token_width = 10;
-		$job_id = str_pad($job_id, $job_id_token_width, '0', STR_PAD_LEFT);
-			
-		}while(file_exists("results/".$job_id));
-			
-		mkdir("results/".$job_id);
-		mkdir("results/".$job_id."/input");
-		mkdir("results/".$job_id."/output");
-		mkdir("results/".$job_id."/tmp");
-		
-		$job_json["job"]["job_id"] = $job_id;
-		$job_json["job"]["transformation_id"] = ltrim($transformation, '0');
-		$job_json["job"]["version_id"] = ltrim($version, '0');
-		$job_json["job"]["input_file_url"] = $input_file_url;
-		$job_json["job"]["input_file_zipped"] = $input_file_zipped;
-		$job_json["job"]["query"] = (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) ? 'https' : 'http')."://".$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
-		//ToDo error handling urls with parameters or slash at the end
-		$input_file_name = substr($input_file_url, strrpos($input_file_url,"/")+1);
-		$url = substr($input_file_url, 0, strrpos($input_file_url,"/")+1);
-		$job_json["job"]["input_file"] = "input/".$input_file_name;
-		//error_log($url);
-		//error_log($input_file_name, 0);
-		//error_log($input_file_url, 0);
-		error_log($url . rawurlencode($input_file_name));
-		//error_log(rawurlencode($input_file_url));
-		
-		$input_file_url = $url . rawurlencode($input_file_name);
-		$input_file_url = str_replace("%3F", "?", $input_file_url);
-		$input_file_url = str_replace("%26", "&", $input_file_url);
-		if (!filter_var($input_file_url, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE) && !filter_var($url, FILTER_VALIDATE_URL)) {
-			echo "Invalid URL";
-			return;
-		}
-		$input_file_content = @file_get_contents($input_file_url);
-		$length = strlen($input_file_content);
-		if ($length == 0) {
-			//ToDo error handling
-			echo "Error: File not found";
-			return;
-		}
-		elseif ($length > 100000000) {
-			// ToDo error handling
-			echo "Error: File larger than 100MB";
-			return;
-		}
-		elseif ($job_json["job"]["transformation_id"] == "5" && substr($input_file_content, 0, 5) != "<?xml") {
-			//ToDo error handling
-			echo "Error: File is not XML";
-			return;
-		}
-		if ($input_file_content)
-			file_put_contents("results/".$job_id."/".$job_json["job"]["input_file"],$input_file_content);
-		
-		foreach ($_GET as $parameter => $value) {
-			if(substr($parameter,0,1)=="_"){
-				$job_json["job"]["parameters"][substr($parameter,1)] = $value;
+			if($transformation_json["version"]["engine"]=="xslt")
+				$job_json = xslt_transformation($job_json,$transformation_json);
+			else if($transformation_json["version"]["engine"]=="python")
+				$job_json = python_transformation($job_json,$transformation_json);
+			else if($transformation_json["version"]["engine"]=="pdi")
+				if($transformation_json["version"]["input_format"]=="ABCD 2.06")
+					$job_json = dwca_transformation($job_json,$transformation_json);
+				else
+					$job_json = cdmlight_transformation($job_json,$transformation_json);
+			else{
+				//ToDo error: unsupported engine
+				//remove directory?
+				//
 			}
+			
+			// Remove tmp folder
+			rrmdir("results/".$job_id."/tmp");
+			
+			$job_json["job"]["finish_time"] = date("c",strtotime ("+2 seconds"));
+			$job_json["job"]["combined_download"] = $job_id.".zip";
+			$result_caching_in_hours = "24";
+			$job_json["job"]["job_expiration_date"] = date("c",strtotime ("+".$result_caching_in_hours." hours"));
+			/*
+	{"job": {
+		"job_id": "9297105672",
+		"transformation_id": "1",
+		"version_id": "2",
+		"input_file_url":"https://data.example.org/my-dataset/observations.zip",
+		"input_file_zipped":"false",
+		"input_file":"input/observations.zip"
+		"parameters": [{"result_file_name": "my_data_results.xml"}],
+		"status": "complete",
+		"start_time": "2019-07-15T13:37:24.782",
+		"finish_time": "2019-07-15T13:37:26.275",
+		"result_file": "my_data_results.xml",
+		"combined_download": "9297105672.zip",
+		"job_expiration_date": "2019-08-15T13:37:26.275"
+	}}
+			
+			*/
+			file_put_contents("results/".$job_id."/job.json",json_encode($job_json));
+			header("Location: results/".$job_id."/");
+		}else{
+			//ToDo error handling
+			return;
 		}
-		$job_json["job"]["status"] = "processing";
-		$job_json["job"]["start_time"] = date("c");
 		
-		
-		if($transformation_json["version"]["engine"]=="xslt")
-			$job_json = xslt_transformation($job_json,$transformation_json);
-		else if($transformation_json["version"]["engine"]=="python")
-			$job_json = python_transformation($job_json,$transformation_json);
-		else if($transformation_json["version"]["engine"]=="pdi")
-			if($transformation_json["version"]["input_format"]=="ABCD 2.06")
-				$job_json = dwca_transformation($job_json,$transformation_json);
-			else
-				$job_json = cdmlight_transformation($job_json,$transformation_json);
-		else{
-			//ToDo error: unsupported engine
-			//remove directory?
-			//
-		}
-		
-		// Remove tmp folder
-		rrmdir("results/".$job_id."/tmp");
-		
-		$job_json["job"]["finish_time"] = date("c",strtotime ("+2 seconds"));
-		$job_json["job"]["combined_download"] = $job_id.".zip";
-		$result_caching_in_hours = "24";
-		$job_json["job"]["job_expiration_date"] = date("c",strtotime ("+".$result_caching_in_hours." hours"));
-		/*
-{"job": {
-    "job_id": "9297105672",
-    "transformation_id": "1",
-    "version_id": "2",
-    "input_file_url":"https://data.example.org/my-dataset/observations.zip",
-    "input_file_zipped":"false",
-	"input_file":"input/observations.zip"
-    "parameters": [{"result_file_name": "my_data_results.xml"}],
-    "status": "complete",
-    "start_time": "2019-07-15T13:37:24.782",
-    "finish_time": "2019-07-15T13:37:26.275",
-    "result_file": "my_data_results.xml",
-    "combined_download": "9297105672.zip",
-    "job_expiration_date": "2019-08-15T13:37:26.275"
-}}
-		
-		*/
-		file_put_contents("results/".$job_id."/job.json",json_encode($job_json));
-		header("Location: results/".$job_id."/");
-	}else{
-		//ToDo error handling
+		//check for engine, pass to engine
 		return;
+		
+	}else if($service == "results"){
+		$job_id = get_url_parameter('job');
+		$task = get_url_parameter('task');
+		if(file_exists("results/".$job_id."/job.json")){
+			$string = file_get_contents("results/".$job_id."/job.json");
+			header('Content-Type: application/json; charset=utf-8');
+			echo $string;
+		}else{
+			//ToDo 404: unknown job
+			http_response_code (404);
+			echo "unknonwn job";
+		}
 	}
-	
-	//check for engine, pass to engine
-	return;
-	
-}else if($service == "results"){
-	$job_id = get_url_parameter('job');
-	$task = get_url_parameter('task');
-	//ToDo wait 2 seconds
-	if($task == "delete"){
-		//ToDo delete task
+} else if ($method == 'DELETE') {
+	if($service == "results"){
+		$job_id = get_url_parameter('job');
+		sleep(2);
 		rrmdir("results/".$job_id."/");
-		echo "deleted ".$job_id;
-		return;
-	}
-	if(file_exists("results/".$job_id."/job.json")){
-		$string = file_get_contents("results/".$job_id."/job.json");
+		$output = array();
+		$output["job_id"] = $job_id;
+		$output["status"] = "deleted";
 		header('Content-Type: application/json; charset=utf-8');
-		echo $string;
-	}else{
-		//ToDo 404: unknown job
-		http_response_code (404);
-		echo "unknonwn job";
+		echo json_encode($output);
 	}
+} else {
+	http_response_code (405);
+	echo "Method not allowed";
 }
 
 function get_latest_version($transformation_id_padded){

--- a/api/index.php
+++ b/api/index.php
@@ -381,13 +381,21 @@ if ($method == 'GET') {
 } else if ($method == 'DELETE') {
 	if($service == "results"){
 		$job_id = get_url_parameter('job');
-		sleep(2);
-		rrmdir("results/".$job_id."/");
 		$output = array();
-		$output["job_id"] = $job_id;
-		$output["status"] = "deleted";
-		header('Content-Type: application/json; charset=utf-8');
-		echo json_encode($output);
+		if(!file_exists("results/".$job_id."/job.json")){
+			http_response_code (404);
+			$output["error_code"] = 404;
+			$output["error_message"] = "Job not found";
+			header('Content-Type: application/json; charset=utf-8');
+			echo json_encode($output);
+		}else{
+			sleep(2);
+			rrmdir("results/".$job_id."/");
+			$output["job_id"] = $job_id;
+			$output["status"] = "deleted";
+			header('Content-Type: application/json; charset=utf-8');
+			echo json_encode($output);
+		}
 	}
 } else {
 	http_response_code (405);


### PR DESCRIPTION
#### Tickets
[#26]

#### Justification
Users may decide to delete a result from temporary storage before the standard retention time elapses. Therefore, the DTS must provide a delete option.

#### Code changes
index.php
- identify request HTTP method
- if `GET` received, then process request as before
- if `DELETE` was sent, then check service and if file exists
  - if so, then delete and output a JSON with the job ID and state
  - if not, then return a both a 404 code and a error message

htaccess
- Comment out redirection rule previously meant for a different deletion implementation
