### PR TITLE
[#24] Handling of unknown engines

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -315,8 +315,16 @@ if($service == "transformations"){
 				$job_json = cdmlight_transformation($job_json,$transformation_json);
 		else{
 			//ToDo error: unsupported engine
-			//remove directory?
-			//
+			error_log("Invocation of an unsupported engine: ".$transformation_json["version"]["engine"]." for transformation ".$transformation_json["version"]["transformation_id"]." version ".$transformation_json["version"]["version_id"])." in job ".$job_id;
+			header('Content-Type: application/json; charset=utf-8');
+			http_response_code (501);
+			$output = array();
+			$output["error_code"] = 501;
+			$output["error_message"] = "Engine not implemented";
+			echo json_encode($output);
+			return;
+			//remove directory
+			//rrmdir("results/".$job_id);
 		}
 		
 		// Remove tmp folder

--- a/api/index.php
+++ b/api/index.php
@@ -303,7 +303,6 @@ if($service == "transformations"){
 		$job_json["job"]["status"] = "processing";
 		$job_json["job"]["start_time"] = date("c");
 		
-		
 		if($transformation_json["version"]["engine"]=="xslt")
 			$job_json = xslt_transformation($job_json,$transformation_json);
 		else if($transformation_json["version"]["engine"]=="python")
@@ -314,7 +313,7 @@ if($service == "transformations"){
 			else
 				$job_json = cdmlight_transformation($job_json,$transformation_json);
 		else{
-			//ToDo error: unsupported engine
+			rrmdir("results/".$job_id);
 			error_log("Invocation of an unsupported engine: ".$transformation_json["version"]["engine"]." for transformation ".$transformation_json["version"]["transformation_id"]." version ".$transformation_json["version"]["version_id"])." in job ".$job_id;
 			header('Content-Type: application/json; charset=utf-8');
 			http_response_code (501);
@@ -323,8 +322,6 @@ if($service == "transformations"){
 			$output["error_message"] = "Engine not implemented";
 			echo json_encode($output);
 			return;
-			//remove directory
-			//rrmdir("results/".$job_id);
 		}
 		
 		// Remove tmp folder

--- a/config.php
+++ b/config.php
@@ -1,6 +1,6 @@
 <?php
 
 # Available services
-$services = array('transformations', 'transform');
+$services = array('transformations', 'transform', 'results');
 
 ?>  


### PR DESCRIPTION
#### Tickets
[#24]

#### Justification
In order to prevent the application from running into failure when calling an `index.json` that contains an unknown engine specification, appropriate handling of this scenario must be implemented.

#### Code changes
index.php
- remove folder of current job
- log corresponding error
- return a JSON with a 501 error, as the engine may not have been implemented yet
