### PR TITLE
Handling of input file urls containing url parameters

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -290,14 +290,14 @@ if ($method == 'GET') {
 			$job_json["job"]["input_file_url"] = $input_file_url;
 			$job_json["job"]["input_file_zipped"] = $input_file_zipped;
 			$job_json["job"]["query"] = (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) ? 'https' : 'http')."://".$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
-			$input_file_name = substr($input_file_url, strrpos($input_file_url,"/")+1);
-			$input_file_name = (strpos($input_file_name, "?") !== false) ? substr($input_file_name, 0, strpos($input_file_name, "?")) : $input_file_name;
-			$url = substr($input_file_url, 0, strrpos($input_file_url,"/")+1);
-			$job_json["job"]["input_file"] = "input/".$input_file_name;
-			error_log($url . rawurlencode($input_file_name));
+			# File name creation (avoids some corrupting characters)
+			$input_file_name = parse_url($input_file_url)["path"];
+			$input_file_name = (strpos($input_file_name, "/") !== false) ? substr($input_file_name, strrpos($input_file_name,"/")+1) : $input_file_name;
+			$input_file_name = (strpos($input_file_name, ".") !== false) ? substr($input_file_name, 0, strpos($input_file_name, ".")) : $input_file_name;
 			
-			$input_file_url = $url . rawurlencode($input_file_name);
-			$input_file_url = rawurldecode($input_file_url);
+			$input_file_url = rawurldecode(rawurlencode($input_file_url));
+			$url = parse_url($input_file_url)["scheme"]."://".parse_url($input_file_url)["host"]."/";
+			$job_json["job"]["input_file"] = "input/".$input_file_name;
 			if (!filter_var($input_file_url, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE) && !(filter_var(substr($input_file_url, 0, strpos($input_file_url, "?")), FILTER_VALIDATE_URL) || filter_var($url, FILTER_VALIDATE_URL))) {
 				header('Content-Type: application/json; charset=utf-8');
 				http_response_code (404);
@@ -310,6 +310,8 @@ if ($method == 'GET') {
 			}
 			$input_file_url = (strpos($input_file_url, " ") !== false) ? str_replace(" ", "%20", $input_file_url) : $input_file_url; # file_get_contents does not like spaces in URLs
 			$input_file_content = @file_get_contents($input_file_url);
+			$header = @get_headers($input_file_url);
+			$is_xml = !(str_replace("/xml", "", $header) == $header) || substr($input_file_content, 0, 5) == "<?xml";
 			$length = strlen($input_file_content);
 			if ($length == 0) {
 				header('Content-Type: application/json; charset=utf-8');
@@ -331,7 +333,7 @@ if ($method == 'GET') {
 				error_log("File larger than 100MB: ".$input_file_url);
 				return;
 			}
-			elseif ($job_json["job"]["transformation_id"] == "5" && substr($input_file_content, 0, 5) != "<?xml") { # TODO: Valid xml must not contain a declaration node
+			elseif ($job_json["job"]["transformation_id"] == "5" && !$is_xml) {
 				header('Content-Type: application/json; charset=utf-8');
 				http_response_code (404);
 				$output = array();

--- a/api/index.php
+++ b/api/index.php
@@ -497,7 +497,7 @@ function python_transformation($job_json,$transformation_json){
 	$result_file = "results/".$job_json["job"]["job_id"]."/".$job_json["job"]["result_file"];
 	
 	//TODO: Specify python version in configuration
-	$command = "python ".$python_file." ".$input_file." ".$result_file." ".$style_file;
+	$command = "python3 ".$python_file." ".$input_file." ".$result_file." ".$style_file;
 	//TODO: Execute command without waiting for it to finish
 	shell_exec($command);
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -191,7 +191,7 @@
                     {
                         "name": "input_file_url",
                         "in": "query",
-                        "description": "URL of input file",
+                        "description": "URL of the input file (UTF-8 encoded if it includes parameters)",
                         "required": true,
                         "schema": {
                             "type": "string"

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
 A transformation job can be initiated using the <i>transform</i> service, which accepts the following four parameters:<br>
 <i>transformation:</i> ID of the transformation to be executed,<br>
 <i>version:</i> version ID (optional),<br>
-<i>input_file_url:</i> URL of the source document,<br>
+<i>input_file_url:</i> URL of the source document (UTF-8 encoded if it contains URL parameters),<br>
 <i>input_file_zipped:</i> specifies whether the source document is zipped or not.</p>
 <p>A list of transformations offered by the service can be retrieved by using <a target="_blank" href="api/transformations/">this request</a>.<br>&nbsp;</p>
 


### PR DESCRIPTION
#### Tickets
[#34]

#### Justification
Parameters in input file URLs could not be processed correctly by the DTS. This affected the readout of these URLs from the API call as well as the correct caching of input files, which is critical for seamless conversion to the designated target format. In addition, the necessity of UTF-8 encoding of input file URLs containing parameters needed to be properly documented in both the OpenAPI documentation and in the service's wiki [page](https://transformation.gfbio.org).

#### Code changes
index.php
- removal of corrupting characters from file names (".", "/") and encoding of space characters from URLs
- _$url_ creation through input file URL parsing
- adjusted both input URL security and XML format checks

openapi.json

index.html
