### PR TITLE
[#44] Added custom logging function

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -183,6 +183,12 @@ if ($method == 'GET') {
 			echo json_encode($output);
 		}
 	}else if($service == "transform"){
+
+		$request_url_protocol = (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) ? 'https' : 'http')."://";
+		$request_url = $request_url_protocol.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
+		$remote_ip = $_SERVER['REMOTE_ADDR'];
+		log_request($request_url, $remote_ip);
+		
 		$transformation = get_url_parameter('transformation');
 		$version = get_url_parameter('version');
 		$input_file_url = get_url_parameter('input_file_url');
@@ -289,7 +295,7 @@ if ($method == 'GET') {
 			$job_json["job"]["version_id"] = ltrim($version, '0');
 			$job_json["job"]["input_file_url"] = str_replace(" ","%20",$input_file_url);
 			$job_json["job"]["input_file_zipped"] = $input_file_zipped;
-			$job_json["job"]["query"] = (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) ? 'https' : 'http')."://".$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
+			$job_json["job"]["query"] = $request_url;
 			# File name creation (avoids some corrupting characters)
 			$input_file_name = parse_url($input_file_url)["path"];
 			$input_file_name = (strpos($input_file_name, "/") !== false) ? substr($input_file_name, strrpos($input_file_name,"/")+1) : $input_file_name;

--- a/api/utils.php
+++ b/api/utils.php
@@ -90,3 +90,10 @@ function get_creative_commons_icon($license){
 		return "";
 	}
 }
+
+function log_request($request_url, $remote_addr){
+	$log_file = dirname(__FILE__, 4)."/log/dts/transform_requests.log";
+	// $log_file = dirname(__FILE__, 4)."/transform_requests.log"; # for local testing
+	$timestamp = date("Y-m-d H:i:s");
+	error_log("[$timestamp] $remote_addr requested: $request_url\n", 3, $log_file);
+}

--- a/api/utils.php
+++ b/api/utils.php
@@ -92,8 +92,8 @@ function get_creative_commons_icon($license){
 }
 
 function log_request($request_url, $remote_addr){
-	$log_file = dirname(__FILE__, 4)."/log/dts/transform_requests.log";
-	// $log_file = dirname(__FILE__, 4)."/transform_requests.log"; # for local testing
-	$timestamp = date("Y-m-d H:i:s");
+	$log_file = "/var/log/dts/transform_requests.log";
+	date_default_timezone_set("Europe/Berlin");
+	$timestamp = date("c"); //ISO date time
 	error_log("[$timestamp] $remote_addr requested: $request_url\n", 3, $log_file);
 }


### PR DESCRIPTION
#### Tickets
[#44]

#### Justification
The annual KPI elicitation within NFDI4Biodiversity requires the logging of _transform_ endpoint requests in order to make the service usage quantifiable. For this reason, a custom logging routine has been implemented that records timestamps, IP addresses, and specific request URLs used as API calls. Timestamps allow counting for certain time periods, while IP addresses may help filter out test requests. Finally, it is possible to differentiate individual transformation IDs based on the logged request URLs.

#### Code changes
index.php:
- Check for the used protocol and construct the request URL based on HTTP header information
- Add the variable value to the job file

util.php:
- Added a function that logs the passed request URL and IP address as well as the time of the API call
